### PR TITLE
Liens HTTPS pour les stylesheets et scripts JS

### DIFF
--- a/RMEBuilder/index.html
+++ b/RMEBuilder/index.html
@@ -2,7 +2,7 @@
 <html>
     <head>
         <meta charset="utf-8" />
-        <link href='http://fonts.googleapis.com/css?family=Lato:400,700,900,400italic,700italic,900italic&subset=latin,latin-ext' rel='stylesheet' type='text/css'>
+        <link href='https://fonts.googleapis.com/css?family=Lato:400,700,900,400italic,700italic,900italic&subset=latin,latin-ext' rel='stylesheet' type='text/css'>
         <link rel="stylesheet" href="../style.css" />
         <title>RMEBuilder</title>
     </head>
@@ -16,14 +16,14 @@
           </div>
           <p class="alert">
             Pour faire fonctionner RMEBuilder sur Windows 10,
-            il faut, au moment une erreur survient, faire clique droit sur l'entête de la console 
+            il faut, au moment une erreur survient, faire clique droit sur l'entête de la console
             et choisir "Propriété", ensuite cocher la case "Utiliser l'ancienne console".
-            <br/> 
-            Un grand merci à <a href="https://stackoverflow.com/questions/33873205/install-rhc-client-tools-openshift-on-windows-10/34546532#34546532">ce thread</a> ! 
+            <br/>
+            Un grand merci à <a href="https://stackoverflow.com/questions/33873205/install-rhc-client-tools-openshift-on-windows-10/34546532#34546532">ce thread</a> !
 
             <br /><br />
             Voici une image pour fixer le problème : <a href="images/fix.gif">ICI</a>
-          </p>  
+          </p>
           <p>
             <strong>RMEBuilder</strong> est un outil pour
             faciliter l'installation de script
@@ -79,13 +79,13 @@
             vous pouvez vous servir de <strong>RMEBuilder</strong> pour construire
             plusieurs projets.)
           </p>
-          
+
           <p class="alert">
-            Suite à un problème lié à Ruby 1.9.3, il est impossible d'utiliser RMEBuilder 
-            si ce dernier se situe dans un répertoire dont le chemin contient un caractère 
-            spécial (un accent par exemple) ou qu'il pointe vers des projets contenant des 
+            Suite à un problème lié à Ruby 1.9.3, il est impossible d'utiliser RMEBuilder
+            si ce dernier se situe dans un répertoire dont le chemin contient un caractère
+            spécial (un accent par exemple) ou qu'il pointe vers des projets contenant des
             caractères spéciaux dans leur nom. <br />
-            Nous sommes désolé de ce soucis que nous tâchons de régler en interne. 
+            Nous sommes désolé de ce soucis que nous tâchons de régler en interne.
           </p>
 
           <h2>Utilisation normale</h2>

--- a/RMEBuilder/uk.html
+++ b/RMEBuilder/uk.html
@@ -2,7 +2,7 @@
 <html>
     <head>
         <meta charset="utf-8" />
-        <link href='http://fonts.googleapis.com/css?family=Lato:400,700,900,400italic,700italic,900italic&subset=latin,latin-ext' rel='stylesheet' type='text/css'>
+        <link href='https://fonts.googleapis.com/css?family=Lato:400,700,900,400italic,700italic,900italic&subset=latin,latin-ext' rel='stylesheet' type='text/css'>
         <link rel="stylesheet" href="../style.css" />
         <title>RMEBuilder</title>
     </head>
@@ -16,10 +16,10 @@
           </div>
           <p class="alert">
             If you're using Windows 10, you have to change the properties of the console (just before
-            the bug) : 
+            the bug) :
             Simply select the 'Use Legacy console' on the Options tab. (To find it right click the top left corner of the CMD window and select properties)
             Special thanks to <a href="https://stackoverflow.com/questions/33873205/install-rhc-client-tools-openshift-on-windows-10/34546532#34546532">this thread</a>.
-          </p>  
+          </p>
           <p>
             <strong>RMEBuilder</strong> is a tool for installing scripts in <strong>RPGMaker VXAce</strong>.
             It makes dependency management easier. On top of the comfort it provides, <strong>RMEBuilder</strong>
@@ -111,7 +111,7 @@
 
           <h4>Modifying the schema</h4>
           <p>
-            By default, during the compilation step (which we will see later), 
+            By default, during the compilation step (which we will see later),
             scripts are installed in the order in which they were added. Obviously, you can change the order:
             <ul>
               <li><code class="inline-code">remove package-name</code>: removes the package from the list</li>
@@ -133,7 +133,7 @@
           and assembling them in the <code class="inline-code">Scripts.rvdata2</code> file.</p>
 
           <p class="alert">
-            Be aware that, before compiling your project, it is mandatory that you close it in RPGMaker. 
+            Be aware that, before compiling your project, it is mandatory that you close it in RPGMaker.
             You will be able to open it back later, once the compilation is done.
           </p>
 
@@ -143,7 +143,7 @@
           <p>
             When the <code class="inline-code">build</code> command is used, the application will download all
             unknown scripts, and will then make a <code class="inline-code">Scripts.rvdata2</code> file, which it
-            will merge with the other scripts. 
+            will merge with the other scripts.
             This means your project can have pre-installed scripts without problem. <br />
             Each time the <code class="inline-code">build</code> command is called, elements built by
             <strong>RMEBuilder</strong> are purged. Thus, if you decide to remove an element from your schema

--- a/RMEDoc/index.html
+++ b/RMEDoc/index.html
@@ -3,10 +3,10 @@
   <head>
     <meta charset="utf-8" />
     <title>RME: Documentation officielle</title>
-    <link href='http://fonts.googleapis.com/css?family=Lato:400,700,900,400italic,700italic,900italic&subset=latin,latin-ext' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Lato:400,700,900,400italic,700italic,900italic&subset=latin,latin-ext' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" href="../css/font-awesome.min.css">
     <link rel="stylesheet" href="style.css" />
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
         <script src="stick.js"></script>
   </head>
   <body>

--- a/RMEManual/index.html
+++ b/RMEManual/index.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8" />
     <title>RME: Manuel officiel</title>
-    <link href='http://fonts.googleapis.com/css?family=Lato:400,700,900,400italic,700italic,900italic&subset=latin,latin-ext' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Lato:400,700,900,400italic,700italic,900italic&subset=latin,latin-ext' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" href="template/style.css" />
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
         <script src="stick.js"></script>
   </head>
   <body>

--- a/RMEManual/template/front.html
+++ b/RMEManual/template/front.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8" />
     <title>RME: Manuel officiel</title>
-    <link href='http://fonts.googleapis.com/css?family=Lato:400,700,900,400italic,700italic,900italic&subset=latin,latin-ext' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Lato:400,700,900,400italic,700italic,900italic&subset=latin,latin-ext' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" href="template/style.css" />
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
         <script src="stick.js"></script>
   </head>
   <body>

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <link href='http://fonts.googleapis.com/css?family=Lato:400,700,900,400italic,700italic,900italic&subset=latin,latin-ext' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Lato:400,700,900,400italic,700italic,900italic&subset=latin,latin-ext' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" href="style.css" />
     <title>RMEx</title>
   </head>


### PR DESCRIPTION
Bonjour!

rmex.github.io est host en https mais link à des ressources en http, la plupart des navigateurs modernes empêchent les pages d'avoir du contenu mixé http/https. Résultat : La documentation ne marche pas du tout sur la plupart des navigateurs comme JQuery n'est pas load.

Ce commit change donc tous les liens de ressources pour du https. Certaines pages semblaient être inutilisées mais j'ai changé les liens quand même pour être sûr.

Par accident ce commit enlève également le whitespace inutile à la fin des lignes (désolé, paramètre sublime text) mais cela n'a bien sûr pas d'impact sur le rendu des pages. Aussi y'a une faute d'orthographe dans le titre du commit..